### PR TITLE
fix: styling issues in webkit browsers

### DIFF
--- a/src/styles/base/global.scss
+++ b/src/styles/base/global.scss
@@ -1,7 +1,7 @@
 @import "../utilities/colors.module";
 @import "../utilities/layered-box-shadow";
 @import "../utilities/font-sizes";
-@import "../utilities/spacing.scss";
+@import "../utilities/spacing";
 @import url("https://fonts.googleapis.com/css?family=Montserrat");
 @import url("https://fonts.googleapis.com/css?family=Karla");
 
@@ -11,6 +11,7 @@
 
 html {
     scroll-behavior: smooth;
+    -webkit-text-size-adjust: 100%;
 }
 
 body {


### PR DESCRIPTION
Repro Steps
1. Navigate to the Digit-Inator in a webkit browser (such as Safari) with a mobile screen size

**Expected**: The styling is the same as on other mobile devices
**Actual**: Dimensions are significantly increased for things like buttons

![image](https://user-images.githubusercontent.com/37189243/106393818-1f515e00-63c7-11eb-84b3-03eaba005e8c.png)
![image](https://user-images.githubusercontent.com/37189243/106393811-16f92300-63c7-11eb-83d6-f954bacf8aba.png)
